### PR TITLE
[bugfix]: check for resolve service

### DIFF
--- a/scripts/setupv2.sh
+++ b/scripts/setupv2.sh
@@ -1073,7 +1073,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 # Create systemd service
-if [ ! -f /etc/systemd/system/tunnelsats-resolve-dns-wg.sh ]; then
+if [ ! -f /etc/systemd/system/tunnelsats-resolve-dns-wg.service ]; then
   echo "[Unit]
 Description= tunnelsats-resolve-dns-wg: Trigger Resolve DNS in case Handshake is older than 2 minutes
 # Disabling any rate limit


### PR DESCRIPTION
This small PR fixes a bug while setting up `tunnelsats-resolve-dns-wg.service`. We were looking for the wrong file which led to unnecessary recreation of the service. 