### PR TITLE
umbrel & raspiblitz raspberry Pi prerequisits added

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Although thinking this is a suitable way of providing a "hybrid service", we wan
 
 ## Preconditions ##
 
-- RaspiBlitz (LND / CLN) v1.8.0
-- Umbrel-OS (LND) 0.5+ recommended
-- Umbrel-OS (CLN not yet recommended or be tech-savvy)
+- RaspiBlitz on raspberry Pi (LND / CLN) v1.8.0+
+- Umbrel-OS on raspberry Pi (LND) 0.5+ recommended
+- Umbrel-OS on raspberry Pi (CLN not yet recommended or be tech-savvy)
 - myNode (LND) v0.2.x 
 - RaspiBolt (LND / CLN)
 - For bare metal systems please check the following requirements:

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Although thinking this is a suitable way of providing a "hybrid service", we wan
 ## Preconditions ##
 
 - RaspiBlitz (LND / CLN) v1.8.0+
-- Umbrel-OS on raspberry Pi (LND) 0.5+ recommended
-- Umbrel-OS on raspberry Pi (CLN not yet recommended or be tech-savvy)
+- Umbrel-OS on Raspberry Pi (LND) 0.5+ recommended
+- Umbrel-OS on Raspberry Pi (CLN not yet recommended or be tech-savvy)
 - myNode (LND) v0.2.x 
 - RaspiBolt (LND / CLN)
 - For bare metal systems please check the following requirements:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Although thinking this is a suitable way of providing a "hybrid service", we wan
 
 ## Preconditions ##
 
-- RaspiBlitz on raspberry Pi (LND / CLN) v1.8.0+
+- RaspiBlitz (LND / CLN) v1.8.0+
 - Umbrel-OS on raspberry Pi (LND) 0.5+ recommended
 - Umbrel-OS on raspberry Pi (CLN not yet recommended or be tech-savvy)
 - myNode (LND) v0.2.x 


### PR DESCRIPTION
added requirement for Umbrel and Raspiblitz supported only on raspberry Pi systems. 

Every other non-pi environments are subject to linux expertise of the customer, and we can't provide service level agreements in case of errors with the automated install routines.