### PR TITLE
[bugfix]: lnd.conf - comment out listen parameter

### DIFF
--- a/scripts/setupv2.sh
+++ b/scripts/setupv2.sh
@@ -1200,7 +1200,7 @@ and duplicated lines could lead to errors.
 
 #########################################
 [Application Options]
-listen=0.0.0.0:9735
+#listen=0.0.0.0:9735
 externalhosts=${vpnExternalDNS}:${vpnExternalPort}
 [Tor]
 tor.streamisolation=false


### PR DESCRIPTION
This PR comments out `listen` setting in lnd.conf that we added for the user to check upfront. Now most setups already have it set by default. Umbrel 0.5.4 seems to get in trouble when adding `listen=0.0.0.0:9735` to `lnd.conf` additionally (it's already a static setting in `export.sh`). Umbrel then ignored TunnelSats config completely, resulting in no external addresses being exposed. 

Therefore this is the proposed solution I'd like to add. In case users are running RaspiBolt which is not setting `listen` by default (but TunnelSats bonus guide does say so), we can advice users to re-enable the line.

```ini
#########################################
[Application Options]
#listen=0.0.0.0:9735
externalhosts=${vpnExternalDNS}:${vpnExternalPort}
[Tor]
tor.streamisolation=false
tor.skip-proxy-for-clearnet-targets=true
#########################################"
```