### PR TITLE
readme: make lnd config more clear + cln warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Running LND only requires a few parameters to be checked and set to activate hyb
 
 With CLN it's a bit trickier. Most node setups like Umbrel, RaspiBolt, RaspiBlitz etc. default CLN's daemon port to `9736`. So in order to route CLN clearnet over VPN, we need to change CLN's default port to `9735`. Locate data directory of your CLN installation. By default CLN's configuration is stored in a file named `config`. Edit the file and look out for network settings section.
 
+⚠️ CLN v23.08: Due to changes in DNS handling, please resolve VPN DNS {vpnDNS} to its original IP address {vpnIP} and enter as described below.
+
 #### RaspiBolt Setup
 
   ```ini

--- a/README.md
+++ b/README.md
@@ -135,11 +135,15 @@ Running LND only requires a few parameters to be checked and set to activate hyb
 
   ```ini
   [Application Options]
+  # omit the folloowing listen setting for Umbrel v5+
   listen=0.0.0.0:9735
-  externalhosts={vpnDNS}:{vpnPort} #these infos are provided at the end of the setupv2.sh script
+  # the following placeholders {vpnDNS} and {vpnPort}
+  # are provided at the end of the setupv2.sh script
+  externalhosts={vpnDNS}:{vpnPort}
   
   [Tor]
-  # set streamisolation to 'false' if currently set 'true'. if not set at all, just leave it out
+  # set streamisolation to 'false' if currently set 'true'.
+  # if not set at all, just leave it out
   tor.streamisolation=false
   tor.skip-proxy-for-clearnet-targets=true
   ```

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Running LND only requires a few parameters to be checked and set to activate hyb
 
   ```ini
   [Application Options]
-  # omit the folloowing listen setting for Umbrel v5+
+  # omit the listen setting for Umbrel v5+
   listen=0.0.0.0:9735
   # the following placeholders {vpnDNS} and {vpnPort}
   # are provided at the end of the setupv2.sh script


### PR DESCRIPTION
This small PR tries to make LND config more clear (Umbrel 5.x).
The `listen` setting is already used as a cli flag. Setting it also in `lnd.conf` creates a conflict on startup (double bind):
https://github.com/getumbrel/umbrel-apps/blob/master/lightning/exports.sh#L12C60-L12C60

Users should also check if `listen` is already set in their `lnd.conf` (most packages already do this).

For CLN 23.08+: we add a warning to replace DNS with IP address to prevent parsing error in configuration file.