### PR TITLE
[update] renew page: move field order and autofocus

### DIFF
--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -237,7 +237,8 @@ function App() {
 
   // display error reported by backend
   socket.off("error").on("error", (message) => {
-    DEBUG && console.log(`${getDate()} App.js: received error message: ${message}`);
+    DEBUG &&
+      console.log(`${getDate()} App.js: received error message: ${message}`);
     setSpinner(false);
     closeInvoiceModal();
     setPopupMessage(message);
@@ -623,7 +624,7 @@ function App() {
                     rel="noreferrer"
                   >
                     Onion 🧅
-                  </Nav.Link>                  
+                  </Nav.Link>
                   {/*
       <Nav.Link>
       <strong>⚡️ Black Friday Special 20% Off ⚡️</strong>
@@ -683,7 +684,7 @@ function App() {
                     rel="noreferrer"
                   >
                     Server Status 🚨
-                  </NavDropdown.Item>                  
+                  </NavDropdown.Item>
                 </NavDropdown>
               </Nav>
             )}
@@ -720,7 +721,7 @@ function App() {
                     pointerEvents={"none"}
                     Cursor={"not-allowed"}
                   />
-
+                  <p className="price">{server}</p>
                   <hr />
 
                   <Form onSubmit={(e) => handleSubmit(e)}>
@@ -749,16 +750,17 @@ function App() {
                           />
                         </Button>
                       </InputGroup>
+                      {/*
                       <InputGroup>
                         <InputGroup.Text>Server</InputGroup.Text>
                         <Form.Control
                           disabled
-                          value={server}
+                          defaultValue={server}
                           placeholder="Tunnel⚡️Sats Server"
                           onChange={handleChangeServer}
-                          type="text"
                         />
-                      </InputGroup>                      
+                      </InputGroup>
+                      */}
                       <Collapse in={valid}>
                         <div id="example-collapse-text">
                           {

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -750,17 +750,6 @@ function App() {
                           />
                         </Button>
                       </InputGroup>
-                      {/*
-                      <InputGroup>
-                        <InputGroup.Text>Server</InputGroup.Text>
-                        <Form.Control
-                          disabled
-                          defaultValue={server}
-                          placeholder="Tunnel⚡️Sats Server"
-                          onChange={handleChangeServer}
-                        />
-                      </InputGroup>
-                      */}
                       <Collapse in={valid}>
                         <div id="example-collapse-text">
                           {

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -714,7 +714,7 @@ function App() {
               {isRenewSub ? (
                 <>
                   <hr />
-                  <p className="price">connected to city:</p>
+                  <p className="price">connected to server:</p>
                   {/* WorldMap */}
                   <WorldMap
                     selected={country}

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -235,6 +235,13 @@ function App() {
     }
   };
 
+  // display error reported by backend
+  socket.off("error").on("error", (message) => {
+    DEBUG && console.log(`${getDate()} App.js: received error message: ${message}`);
+    setPopupMessage(message);
+    renderPopupModal();
+  });
+
   /*
   socket.removeAllListeners("receiveServer").on("receiveServer", (server) => {
     DEBUG && console.log(`${getDate()} App.js: received server: `, server);

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -238,6 +238,8 @@ function App() {
   // display error reported by backend
   socket.off("error").on("error", (message) => {
     DEBUG && console.log(`${getDate()} App.js: received error message: ${message}`);
+    setSpinner(false);
+    closeInvoiceModal();
     setPopupMessage(message);
     renderPopupModal();
   });

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -728,16 +728,6 @@ function App() {
                     {/* Renew Subscription */}
                     <Form.Group className="updateSubFrom">
                       <InputGroup>
-                        <InputGroup.Text>Server</InputGroup.Text>
-                        <Form.Control
-                          disabled
-                          value={server}
-                          placeholder="Tunnel⚡️Sats Server"
-                          onChange={handleChangeServer}
-                          type="text"
-                        />
-                      </InputGroup>
-                      <InputGroup>
                         <InputGroup.Text>WG Pubkey</InputGroup.Text>
                         <Form.Control
                           enabled
@@ -745,6 +735,7 @@ function App() {
                           placeholder="WireGuard public key (base64 encoded)"
                           isValid={valid}
                           onChange={handleChangePubkey}
+                          autoFocus={true}
                         />
                         <Button
                           variant="secondary"
@@ -758,6 +749,16 @@ function App() {
                           />
                         </Button>
                       </InputGroup>
+                      <InputGroup>
+                        <InputGroup.Text>Server</InputGroup.Text>
+                        <Form.Control
+                          disabled
+                          value={server}
+                          placeholder="Tunnel⚡️Sats Server"
+                          onChange={handleChangeServer}
+                          type="text"
+                        />
+                      </InputGroup>                      
                       <Collapse in={valid}>
                         <div id="example-collapse-text">
                           {

--- a/frontend/client/src/components/WorldMap.js
+++ b/frontend/client/src/components/WorldMap.js
@@ -623,7 +623,7 @@ const WorldMap = (props) => {
               <Popover.Title as="h3">North America</Popover.Title>
               <Popover.Content>
                 <IoLocation color="#ffc700" size={20} />{" "}
-                <strong>Server Location: </strong>🇺🇸 Hillsboro, Oregon
+                <strong>Server Location: </strong>🇺🇸 Hillsboro, OR
                 <br />
                 <br />
                 <FaServer color="#ffc700" size={20} />{" "}

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -361,9 +361,9 @@ io.on("connection", (socket) => {
   // Getting the Invoice from lnbits and forwarding it to the frontend
   socket.on("getInvoice", async (payload) => {
     DEBUG &&
-      DEBUG &&
       logDim(`getInvoice() called by socket id: ${socket.id} with payload
       ${JSON.stringify(payload, null, 4)}`);
+
     if (
       // We need all of those from the client otherwise we do nothing
       !!payload.selection &&

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -197,9 +197,8 @@ app.post(process.env.WEBHOOK, (req, res) => {
               .replace(/^https?:\/\//, "")
               .replace(/\/manager\/$/, "");
             sayWithTelegram({
-              message: `🟢 New Subscription: 🍾\n Price: ${priceDollar}\$\n ServerLocation: ${serverDNS}\n Sats: ${Math.round(
-                amountSats
-              )}💰`,
+              // prettier-ignore
+              message: `🟢 New Subscription: 🍾\n Price: ${priceDollar}\$\n ServerLocation: ${serverDNS}\n Sats: ${Math.round(amountSats)}💰`,
             })
               .then((result) => {
                 DEBUG &&
@@ -280,9 +279,8 @@ app.post(process.env.WEBHOOK_UPDATE_SUB, (req, res) => {
                 invoiceWGKeysMap[index].resultBackend = result;
 
                 sayWithTelegram({
-                  message: `🟢 Renewed Subscription: 🍾\n Price: ${priceDollar}\$\n PubKey: ${publicKey} \n ServerLocation: ${serverURL}\n Sats: ${Math.round(
-                    amountSats
-                  )}💰`,
+                  // prettier-ignore
+                  message: `🟢 Renewed Subscription: 🍾\n Price: ${priceDollar}\$\n PubKey: ${publicKey} \n ServerLocation: ${serverURL}\n Sats: ${Math.round(amountSats)}💰`,
                 })
                   .then((result) => {
                     DEBUG &&
@@ -418,8 +416,8 @@ io.on("connection", (socket) => {
             // report to system
             logDim(`Error - no valid serverURL for ${payload.country}`);
             sayWithTelegram({
-              message: `❗️ Failed to generate invoice: no valid server url for
-              country: ${payload.country}, url: ${serverURL}`,
+              // prettier-ignore
+              message: `❗️ Failed to generate invoice: no valid server url for country: ${payload.country}, url: ${serverURL}`,
             });
 
             //also report to frontend

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -415,11 +415,15 @@ io.on("connection", (socket) => {
               .replace(/^https?:\/\//, "")
               .replace(/\/manager\/$/, "");
           } else {
+            // report to system
             logDim(`Error - no valid serverURL for ${payload.country}`);
             sayWithTelegram({
               message: `❗️ Failed to generate invoice: no valid server url for
               country: ${payload.country}, url: ${serverURL}`,
             });
+
+            //also report to frontend
+            socket.emit("error", "Error fetching server details!");
 
             return;
           }


### PR DESCRIPTION
This PR moves field order on renew page from 
- TS server
- wg pubkey input
to
- wg pubkey input
- TS server

and sets autofocus for field "wg pubkey input" on page switch.
Additionally this PR includes some code formatting improvements using `// prettier-ignore` for telegram messages and replaces "Oregon" with "OR" on tooltip of US West VPN for better readability.