### PR TITLE
scripts: enhancements and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Running LND only requires a few parameters to be checked and set to activate hyb
 
   ```ini
   [Application Options]
-  # omit the listen setting for Umbrel v5+
+  # omit the listen setting for Umbrel v0.5+
   listen=0.0.0.0:9735
   # the following placeholders {vpnDNS} and {vpnPort}
   # are provided at the end of the setupv2.sh script

--- a/scripts/setupv2.sh
+++ b/scripts/setupv2.sh
@@ -941,14 +941,16 @@ if [ $isDocker -eq 1 ]; then
 lightningcontainer=\$(docker ps --format 'table {{.Image}} {{.Names}} {{.Ports}}' | grep 0.0.0.0:9735 | awk '{print \$2}')
 checkdockernetwork=\$(docker network ls  2> /dev/null | grep -c \"docker-tunnelsats\")
 if [ \$checkdockernetwork -eq 0 ]; then
-  if ! docker network create \"docker-tunnelsats\" --subnet \"10.9.9.0/25\" -o \"com.docker.network.driver.mtu\"=\"1420\"; then
+  if ! docker network create \"docker-tunnelsats\" --subnet \"10.9.9.0/25\" -o \"com.docker.network.driver.mtu\"=\"1420\" >/dev/null; then
     exit 1
   fi
 fi
 if [ ! -z \$lightningcontainer ]; then
   inspectlncontainer=\$(docker inspect \$lightningcontainer | grep -c \"tunnelsats\")
   if [ \$inspectlncontainer -eq 0 ]; then
-    docker network connect --ip 10.9.9.9 docker-tunnelsats \$lightningcontainer  >/dev/null
+    if ! docker network connect --ip 10.9.9.9 docker-tunnelsats \$lightningcontainer >/dev/null; then
+      exit 1
+    fi
   fi
 fi
 exit 0" >/etc/wireguard/tunnelsats-docker-network.sh

--- a/scripts/setupv2.sh
+++ b/scripts/setupv2.sh
@@ -9,7 +9,7 @@
 ##########UPDATE IF YOU MAKE A NEW RELEASE#############
 major=0
 minor=1
-patch=31
+patch=32
 
 #Helper
 function valid_ipv4() {

--- a/scripts/uninstallv2.sh
+++ b/scripts/uninstallv2.sh
@@ -51,6 +51,9 @@ done
 
 # Check if docker / non-docker
 isDocker=0
+# get umbrel user
+UMBREL_USER=${SUDO_USER:-${USER}}
+
 while true; do
     read -p "What lightning node package are you running?: 
     1) RaspiBlitz
@@ -71,6 +74,7 @@ while true; do
         echo "> Umbrel"
         echo
         isDocker=1
+        HOME_DIR="/home/$UMBREL_USER"
         break
         ;;
 
@@ -161,8 +165,8 @@ while true; do
         # modify LND configuration
         path=""
         if [ -f /mnt/hdd/lnd/lnd.conf ]; then path="/mnt/hdd/lnd/lnd.conf"; fi
-        if [ -f /home/umbrel/umbrel/lnd/lnd.conf ]; then path="/home/umbrel/umbrel/lnd/lnd.conf"; fi
-        if [ -f /home/umbrel/umbrel/app-data/lightning/data/lnd/lnd.conf ]; then path="/home/umbrel/umbrel/app-data/lightning/data/lnd/lnd.conf"; fi
+        if [ -f "$HOME_DIR"/umbrel/lnd/lnd.conf ]; then path="$HOME_DIR/umbrel/lnd/lnd.conf"; fi
+        if [ -f "$HOME_DIR"/umbrel/app-data/lightning/data/lnd/lnd.conf ]; then path="$HOME_DIR/umbrel/app-data/lightning/data/lnd/lnd.conf"; fi
         if [ -f /data/lnd/lnd.conf ]; then path="/data/lnd/lnd.conf"; fi
         if [ -f /embassy-data/package-data/volumes/lnd/data/main/lnd.conf ]; then path="/embassy-data/package-data/volumes/lnd/data/main/lnd.conf"; fi
         if [ -f /mnt/hdd/mynode/lnd/lnd.conf ]; then path="/mnt/hdd/mynode/lnd/lnd.conf"; fi
@@ -250,7 +254,7 @@ while true; do
         # modify CLN configuration
         path=""
         if [ -f /mnt/hdd/app-data/.lightning/config ]; then path="/mnt/hdd/app-data/.lightning/config"; fi
-        if [ -f /home/umbrel/umbrel/app-data/core-lightning/data/lightningd/bitcoin/config ]; then path="/home/umbrel/umbrel/app-data/core-lightning/data/lightningd/bitcoin/config"; fi
+        if [ -f "$HOME_DIR"/umbrel/app-data/core-lightning/data/lightningd/bitcoin/config ]; then path="$HOME_DIR/umbrel/app-data/core-lightning/data/lightningd/bitcoin/config"; fi
         if [ -f /data/lightningd/config ]; then path="/data/lightningd/config"; fi
 
         if [ "$path" != "" ]; then
@@ -272,7 +276,7 @@ while true; do
             fi
 
             # Umbrel 0.5+ CLN: restore default configuration
-            if [ "$path" == "/home/umbrel/umbrel/app-data/core-lightning/data/lightningd/bitcoin/config" ]; then
+            if [ "$path" == "$HOME_DIR/umbrel/app-data/core-lightning/data/lightningd/bitcoin/config" ]; then
                 deleteBind=$(grep -n "^bind-addr" "$path" | cut -d ':' -f1)
                 if [ "$deleteBind" != "" ]; then
                     sed -i "${deleteBind}d" "$path" >/dev/null
@@ -293,8 +297,8 @@ while true; do
                 fi
             fi
             # Umbrel 0.5+ CLN: restore assigned port
-            if [ "$path" == "/home/umbrel/umbrel/app-data/core-lightning/exports.sh" ]; then
-                getPort=$(grep -n "export APP_CORE_LIGHTNING_DAEMON_PORT=\"9735\"" | cut -d ':' -f1)
+            if [ "$path" == "$HOME_DIR/umbrel/app-data/core-lightning/exports.sh" ]; then
+                getPort=$(grep -n "export APP_CORE_LIGHTNING_DAEMON_PORT=\"9735\"" "$path" | cut -d ':' -f1)
                 if [ "$getPort" != "" ]; then
                     sed -i "s/export APP_CORE_LIGHTNING_DAEMON_PORT=\"9735\"/export APP_CORE_LIGHTNING_DAEMON_PORT=\"9736\"/g" "$path" >/dev/null
                 fi
@@ -308,6 +312,22 @@ while true; do
                     echo
                 fi
             fi
+            # Umbrel 0.5+ CLN: restore binding
+            if [ "$path" == "$HOME_DIR/umbrel/app-data/core-lightning/docker-compose.yml" ]; then
+                getBind=$(grep -n "\- \-\-bind-addr" "$path" | cut -d ':' -f1)
+                if [ "$getBind" != "" ]; then
+                    sed -i "s/#\- \-\-bind-addr/\- \-\-bind-addr/g" "$path" >/dev/null
+                fi
+                #recheck
+                checkAgain=$(grep -c "#\- \-\-bind-addr" "$path")
+                if [ $checkAgain -ne 0 ]; then
+                    echo "> Restoring binding failed. Please check ${path} file and uncomment '- --bind-addr=\${APP_CORE_LIGHTNING_DAEMON_IP}:9735' ."
+                    echo
+                else
+                    echo "> Umbrel 0.5+ CLN: binding successfully restored."
+                    echo
+                fi
+            fi             
         fi
         break
         ;;

--- a/scripts/uninstallv2.sh
+++ b/scripts/uninstallv2.sh
@@ -9,7 +9,7 @@
 ##########UPDATE IF YOU MAKE A NEW RELEASE#############
 major=0
 minor=0
-patch=9
+patch=10
 
 # check if sudo
 if [ "$EUID" -ne 0 ]; then


### PR DESCRIPTION
Replaces #124
Closes #124

This PR tries to generalize Umbrel setup instructions for both RPi and x86 environments and also fixes a nftables bug. 

setupv2.sh:
- add missing instruction step for CLN configuration
- enhancing ip range to 0.0.0.0 for p2p broadcast

uninstallv2.sh:
- generalizing home dir by trying to grab umbrel user automatically (does not catch custom installation paths for x86 setups)
- adding auto-restoration of binding parameter in `docker-compose.yml` for CLN setup
- adding missing path var to restore port in `exports.sh`